### PR TITLE
Update NessusReportMerger.ps1

### DIFF
--- a/NessusReportMerger.ps1
+++ b/NessusReportMerger.ps1
@@ -43,7 +43,7 @@ Param
 Write-Host Merging .nessus files in folder $filepath 
 
 # Get all .nessus files
-$files = Get-ChildItem $filepath -Filter *.nessus
+$files = Get-ChildItem $filepath -Filter *.nessus -Recurse | ForEach-Object{$_.Fullname}
 
 # Check if the folder contains .nessus files
 if ($files.count -eq 0) 


### PR DESCRIPTION
Updated $files list assignment to use absolute file path rather than just the file name. eg. "c:\users\bob\downloads\nessusoutput.nessus" instead of just "nessusoutput.nessus"